### PR TITLE
fix: Improve cover image display and error handling

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -157,6 +157,17 @@ export const fulltextSearch = async (query, searchType = 'simple_query_string', 
   }
 }
 
+// 書影取得機能
+export const getWorkCover = async (workId) => {
+  try {
+    const response = await apiV1.get(`/covers/work/${encodeURIComponent(workId)}`)
+    return response.data
+  } catch (error) {
+    console.error('Work cover API error:', error)
+    return null
+  }
+}
+
 // ヘルスチェック（非バージョン管理）
 export const healthCheck = async () => {
   try {


### PR DESCRIPTION
- Separate styling for nodes with and without cover images
- Add image preloading to detect and handle display errors
- Implement proper fallback for failed cover image loads
- Enhance text readability with background styling
- Add comprehensive console logging for debugging

🤖 Generated with [Claude Code](https://claude.ai/code)